### PR TITLE
Defaulting BikeStatus name to Id if empty

### DIFF
--- a/src/BikeshareClient/BikeshareClient/BikeshareClient.csproj
+++ b/src/BikeshareClient/BikeshareClient/BikeshareClient.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>3.2.0</ReleaseVersion>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <ReleaseVersion>3.2.1</ReleaseVersion>
+    <VersionPrefix>3.2.1</VersionPrefix>
     <Title>BikeshareClient</Title>
     <Authors>andmos</Authors>
     <Description>Dotnet client for bike share systems implementing the General Bikeshare Feed Specification (GBFS).</Description>

--- a/src/BikeshareClient/BikeshareClient/Models/BikeStatus.cs
+++ b/src/BikeshareClient/BikeshareClient/Models/BikeStatus.cs
@@ -18,7 +18,7 @@ namespace BikeshareClient.Models
 			[JsonProperty("is_disabled"), JsonConverter(typeof(IntegerToBoolConverter))] bool disabled)
         {
 			Id = id;
-			Name = name;
+			Name = string.IsNullOrEmpty(name) ? id : name;
 			Latitude = latitude;
 			Longitude = longitude;
 			Reserved = reserved;

--- a/src/BikeshareClient/TestBikeshareClient/TestBikeShareClient.cs
+++ b/src/BikeshareClient/TestBikeshareClient/TestBikeShareClient.cs
@@ -139,8 +139,8 @@ namespace TestBikeshareClient
 
 
 		[Theory]
-        [InlineData(@"http://hamilton.socialbicycles.com/opendata/")]
         [InlineData(@"http://coast.socialbicycles.com/opendata/")]
+        [InlineData(@"https://gbfs.nextbike.net/maps/gbfs/v1/nextbike_mr/gbfs.json")]
         public async Task GetBikeStatusAsync_GivenCorrectBaseUrl_ReturnsBikesStatus(string endpoint)
         {
 			var client = new Client(endpoint);
@@ -151,8 +151,8 @@ namespace TestBikeshareClient
         }
 
 		[Theory]
-        [InlineData(@"http://hamilton.socialbicycles.com/opendata/gbfs.json")]
         [InlineData(@"http://coast.socialbicycles.com/opendata/gbfs.json")]
+        [InlineData(@"https://gbfs.nextbike.net/maps/gbfs/v1/nextbike_mr/gbfs.json")]
         public async Task GetBikeStatusAsync_GivenCorrectBaseUrlWithGbfsDiscoveryFile_ReturnsBikesStatus(string endpoint)
         {
             var client = new Client(endpoint);
@@ -163,8 +163,8 @@ namespace TestBikeshareClient
         }
 
         [Theory]
-        [InlineData(@"http://hamilton.socialbicycles.com/opendata/gbfs.json")]
         [InlineData(@"http://coast.socialbicycles.com/opendata/gbfs.json")]
+        [InlineData(@"https://gbfs.nextbike.net/maps/gbfs/v1/nextbike_mr/gbfs.json")]
         public async Task GetBikeStatusAsync_GivenCorrectBaseUrlWithGbfsDiscoveryFile_ReturnsValidPropertyValues(string endpoint)
         {
             var client = new Client(endpoint);


### PR DESCRIPTION
`free_bike_status.json` don't have a `name` field, but the client has. Defaults the `Name` property to `Id` if empty.