### PR TITLE
Added constructor with only HTTPClient as parameter

### DIFF
--- a/src/BikeshareClient/BikeshareClient/BikeshareClient.csproj
+++ b/src/BikeshareClient/BikeshareClient/BikeshareClient.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
-    <ReleaseVersion>3.3.1</ReleaseVersion>
-    <VersionPrefix>3.3.1</VersionPrefix>
+    <ReleaseVersion>3.3.2</ReleaseVersion>
+    <VersionPrefix>3.3.2</VersionPrefix>
     <Title>BikeshareClient</Title>
     <Authors>andmos</Authors>
     <Description>Dotnet client for bike share systems implementing the General Bikeshare Feed Specification (GBFS).</Description>

--- a/src/BikeshareClient/BikeshareClient/Client.cs
+++ b/src/BikeshareClient/BikeshareClient/Client.cs
@@ -17,6 +17,11 @@ namespace BikeshareClient
             _bikeShareDataProvider = new BikeShareDataProvider(gbfsBaseUrl, httpClient);
         }
 
+        public Client(HttpClient httpClient)
+        {
+            _bikeShareDataProvider = new BikeShareDataProvider(httpClient);
+        }
+
         public async Task<IEnumerable<Feed>> GetAvailableFeedsAsync()
         {
             var gbfsDiscovery = await _bikeShareDataProvider.GetBikeShareData<GbfsDTO>();

--- a/src/BikeshareClient/BikeshareClient/Providers/BikeShareDataProvider.cs
+++ b/src/BikeshareClient/BikeshareClient/Providers/BikeShareDataProvider.cs
@@ -30,6 +30,18 @@ namespace BikeshareClient.Providers
             
         }
 
+        public BikeShareDataProvider(HttpClient httpClient)
+        {
+            if (httpClient?.BaseAddress == null)
+            {
+                throw new ArgumentNullException($"HttpClient with GBFS BaseAddress must be set.");
+            }
+
+            _gbfsBaseUrl = httpClient?.BaseAddress?.ToString();
+            
+            _httpClient = httpClient;
+        }
+
         public async Task<T> GetBikeShareData<T>()
         {
             return await GetProviderDtoAsync<T>(FindResourceType<T>());

--- a/src/BikeshareClient/TestBikeshareClient/ProvidersTests/TestBikeShareDataProvider.cs
+++ b/src/BikeshareClient/TestBikeshareClient/ProvidersTests/TestBikeShareDataProvider.cs
@@ -102,9 +102,15 @@ namespace TestBikeshareClient.ProvidersTests
         }
 
         [Fact]
-        public void GetBikeShareData_GivenEmptyHTTPClientWithEmptyBaseUrl_ThrowsArgumentNullException()
+        public void GetBikeShareData_GivenEmptyHTTPClientWithNoBaseUrl_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => new BikeShareDataProvider(new HttpClient()));
+        }
+
+                [Fact]
+        public void GetBikeShareData_GivenEmptyHTTPClientWithStringEmptyBaseUrl_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new BikeShareDataProvider(new HttpClient{BaseAddress = new Uri(string.Empty) }));
         }
 
         [Fact]

--- a/src/BikeshareClient/TestBikeshareClient/ProvidersTests/TestBikeShareDataProvider.cs
+++ b/src/BikeshareClient/TestBikeshareClient/ProvidersTests/TestBikeShareDataProvider.cs
@@ -37,6 +37,19 @@ namespace TestBikeshareClient.ProvidersTests
 
         [Theory]
         [InlineData(@"http://gbfs.urbansharing.com/trondheim/")]
+        public async Task GetBikeShareData_GivenHttpClient_ReturnsValidResponse(string endpoint)
+        {
+            var httpClient = new HttpClient {BaseAddress = new Uri(endpoint) };
+            var dataProvider = new BikeShareDataProvider(httpClient);
+
+            var stationDto = await dataProvider.GetBikeShareData<StationDTO>();
+
+            Assert.True(stationDto.TimeToLive != 0);
+            Assert.NotEqual(DateTime.MinValue, stationDto.LastUpdated);
+        }
+
+        [Theory]
+        [InlineData(@"http://gbfs.urbansharing.com/trondheim/")]
         public async Task GetBikeShareData_GivenInvalidBaseUrlAndHttpClientWithValidBaseUrl_ReturnsValidResponse(string endpoint)
         {
             var httpClient = new HttpClient { BaseAddress = new Uri(endpoint) };
@@ -86,6 +99,12 @@ namespace TestBikeshareClient.ProvidersTests
         public void GetBikeShareData_GivenEmptyBaseUrlAndHTTPClientWithEmptyBaseUrl_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => new BikeShareDataProvider("", new HttpClient()));
+        }
+
+        [Fact]
+        public void GetBikeShareData_GivenEmptyHTTPClientWithEmptyBaseUrl_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new BikeShareDataProvider(new HttpClient()));
         }
 
         [Fact]

--- a/src/BikeshareClient/TestBikeshareClient/ProvidersTests/TestBikeShareDataProvider.cs
+++ b/src/BikeshareClient/TestBikeshareClient/ProvidersTests/TestBikeShareDataProvider.cs
@@ -107,10 +107,16 @@ namespace TestBikeshareClient.ProvidersTests
             Assert.Throws<ArgumentNullException>(() => new BikeShareDataProvider(new HttpClient()));
         }
 
-                [Fact]
-        public void GetBikeShareData_GivenEmptyHTTPClientWithStringEmptyBaseUrl_ThrowsArgumentNullException()
+        [Fact]
+        public void GetBikeShareData_GivenEmptyHTTPClientWithStringEmptyBaseUrl_ThrowsUriFormatException()
         {
-            Assert.Throws<ArgumentNullException>(() => new BikeShareDataProvider(new HttpClient{BaseAddress = new Uri(string.Empty) }));
+            Assert.Throws<System.UriFormatException>(() => new BikeShareDataProvider(new HttpClient{BaseAddress = new Uri(string.Empty) }));
+        }
+
+        [Fact]
+        public void GetBikeShareData_GivenEmptyHTTPClientWithNullForBaseUrl_ThrowsUriFormatException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new BikeShareDataProvider(new HttpClient{BaseAddress = null }));
         }
 
         [Fact]

--- a/src/BikeshareClient/TestBikeshareClient/TestBikeShareClient.cs
+++ b/src/BikeshareClient/TestBikeshareClient/TestBikeShareClient.cs
@@ -58,6 +58,21 @@ namespace TestBikeshareClient
         [InlineData(@"http://gbfs.urbansharing.com/trondheim/")]
         [InlineData(@"http://gbfs.urbansharing.com/bergen-city-bike/")]
         [InlineData(@"http://hamilton.socialbicycles.com/opendata/")]
+        public async Task GetStationsAsync_GivenHttpClientWithValidBaseUrl_ReturnsStations(string baseUrl)
+        {
+            var httpClient = new HttpClient { BaseAddress = new Uri(baseUrl) };
+            var client = new Client(httpClient);
+
+            var clientResponse = await client.GetStationsAsync();
+            var stations = clientResponse.ToList();
+
+            Assert.True(stations.Any());
+        }
+
+        [Theory]
+        [InlineData(@"http://gbfs.urbansharing.com/trondheim/")]
+        [InlineData(@"http://gbfs.urbansharing.com/bergen-city-bike/")]
+        [InlineData(@"http://hamilton.socialbicycles.com/opendata/")]
         public async Task GetStationsAsync_GivenValidBaseUrl_ReturnsStationsWithAddress(string baseUrl)
         {
             var client = new Client(baseUrl);


### PR DESCRIPTION
To support the DependencyInjection client, we need a constructor that only takes the HTTPClient.